### PR TITLE
Fix checking repo url in case given path is relative

### DIFF
--- a/diffanalyze.py
+++ b/diffanalyze.py
@@ -346,7 +346,7 @@ class RepoManager:
         repo = pygit2.Repository(discover_repo_path)
 
         # A different repo is found
-        if repo.remotes['origin'].url != self.repo_url:
+        if repo.remotes['origin'].url != self.repo_url and repo.remotes['origin'].url != os.path.abspath(self.repo_url) :
             OutputManager.print("Found repo is incorrect. Should be:", self.repo_url, "but is:", repo.remotes['origin'].url)
             sys.exit(1)
 


### PR DESCRIPTION
This lets us specify relative repository paths without the interpreter unnecessarily raising an error