### PR TITLE
Exit with an error message when universal-ctags is not installed

### DIFF
--- a/diffanalyze.py
+++ b/diffanalyze.py
@@ -134,6 +134,8 @@ class FileDifferences:
         self.ctags = shutil.which('universalctags')
         if not self.ctags:
             self.ctags = shutil.which('ctags')
+        if not self.ctags:
+            sys.exit('package universal-ctags not found.')
         self.filename = filename
         self.file_extension = FileDifferences.get_extension(filename)
         self.current_fn_map = self.get_fn_names(new_path)


### PR DESCRIPTION
Gives a better idea what's going on than 

```
Traceback (most recent call last):
  File "/home/jruiz/code/diffanalyze/diffanalyze.py", line 732, in <module>
    main(sys.argv[1:])
  File "/home/jruiz/code/diffanalyze/diffanalyze.py", line 705, in main
    repo_manager.compare_patches_in_range(args['revision'],args['range'])
  File "/home/jruiz/code/diffanalyze/diffanalyze.py", line 463, in compare_patches_in_range
    diff_summary = self.compute_diffs(diff, commit, prev_commit, old_repo, new_repo, clone_old, clone_new)
  File "/home/jruiz/code/diffanalyze/diffanalyze.py", line 392, in compute_diffs
    diff_data = FileDifferences(filename, commit_new.hex, old_path=clone_old_path, new_path=clone_new_path)
  File "/home/jruiz/code/diffanalyze/diffanalyze.py", line 140, in __init__
    self.current_fn_map = self.get_fn_names(new_path)
  File "/home/jruiz/code/diffanalyze/diffanalyze.py", line 156, in get_fn_names
    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1278, in _execute_child
    executable = os.fsencode(executable)
  File "/usr/lib/python3.6/os.py", line 800, in fsencode
    filename = fspath(filename)  # Does type-checking of `filename`.
TypeError: expected str, bytes or os.PathLike object, not NoneType
```